### PR TITLE
Use crypto.timingSafeEqual to avoid timing-based attacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.1.2 / 2017-11-30
+==================
+
+  * Validate secret using a constant-time comparison to avoid timing attacks.
+
 1.1.1 / 2015-02-06
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -154,8 +154,16 @@ function GitHooked(ref, action, options) {
 }
 
 function signatureValidation(githooked, options, req, res, buf) {
+  // Use crypto.timingSafeEqual when available to avoid timing attacks
+  // See https://codahale.com/a-lesson-in-timing-attacks/
+  var compareStrings = function(a, b) { return a === b };
+  var compareSecure = function(a, b) {
+    return a.length === b.length && crypto.timingSafeEqual(new Buffer(a), new Buffer(b));
+  }
+  var validateSecret = crypto.timingSafeEqual ? compareSecure : compareStrings;
 
   var providedSignature = req.headers['x-hub-signature'];
+
   // Throw an error if secret was provided but no X-Hub-Signature header present
   if ( !providedSignature ) {
     res.sendStatus(401);
@@ -166,7 +174,7 @@ function signatureValidation(githooked, options, req, res, buf) {
   var ourSignature = 'sha1=' + crypto.createHmac('sha1', options.secret).update(buf.toString()).digest('hex');
 
   // Validate Signatures
-  if ( providedSignature !== ourSignature ) {
+  if ( ! validateSecret(providedSignature, ourSignature) ) {
     res.sendStatus(401);
     githooked.emit('error', 'signature validation failed');
     throw new Error('signature validation failed');


### PR DESCRIPTION
Node added a function to its crypto library, `timingSafeEqual` which can be used to mitigate the risk of a timing-based attack on signatures. (See https://codahale.com/a-lesson-in-timing-attacks for a good explanation of timing attacks).

In short, using a normal string comparison function leaks information about _how_ different the provided signature is from the correct one because a string with a longer matching prefix will take longer to return. This change uses the existing string comparison when `timingSafeEqual` is not available.